### PR TITLE
Add CI for windows builds

### DIFF
--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -19,12 +19,6 @@ jobs:
         with:
           node-version: 18
 
-      - name: Install ffmpeg-static via npm and add to PATH
-        shell: bash 
-        run: |
-          npm install --prefix ./tools ffmpeg-static
-          echo "$GITHUB_WORKSPACE/tools/node_modules/.bin" >> $GITHUB_PATH
-
       - name: Setup MSYS2
         uses: msys2/setup-msys2@v2
         with:
@@ -41,6 +35,29 @@ jobs:
             mingw-w64-x86_64-SDL2_ttf
             mingw-w64-x86_64-libpng
             mingw-w64-x86_64-libsndfile
+
+      - name: Build FFmpeg
+        run: |
+          git clone https://github.com/FFmpeg/FFmpeg.git
+          cd FFmpeg
+          git checkout n7.0.1
+          ./configure --disable-everything \
+            --enable-decoder=cinepak \
+            --enable-decoder=indeo3 \
+            --enable-decoder=pcm_s16le \
+            --enable-demuxer=avi \
+            --enable-demuxer=wav \
+            --enable-protocol=file \
+            --enable-filter=scale \
+            --enable-static \
+            --disable-shared \
+            --disable-doc \
+            --extra-libs=-static \
+            --extra-cflags=--static
+          make -j$(nproc)
+          make install
+          cd ..
+          export PKG_CONFIG_PATH="/usr/local/lib/pkgconfig:$PKG_CONFIG_PATH"
 
       - name: Configure and Build Project
         run: |

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -1,0 +1,69 @@
+name: Windows Build (MSYS2)
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build-windows:
+    runs-on: windows-latest
+
+    defaults:
+      run:
+        shell: msys2 {0}
+
+    steps:
+
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+
+      - name: Setup MSYS2
+        uses: msys2/setup-msys2@v2
+        with:
+          update: true
+          install: >-
+            base-devel
+            git
+            nasm
+            diffutils
+            mingw-w64-x86_64-gcc
+            mingw-w64-x86_64-meson
+            mingw-w64-x86_64-pkg-config
+            mingw-w64-x86_64-SDL2
+            mingw-w64-x86_64-SDL2_ttf
+            mingw-w64-x86_64-libpng
+            mingw-w64-x86_64-libsndfile
+
+      - name: Build FFmpeg
+        run: |
+          git clone https://github.com/FFmpeg/FFmpeg.git
+          cd FFmpeg
+          git checkout n7.0.1
+          ./configure --disable-everything \
+            --enable-decoder=cinepak \
+            --enable-decoder=indeo3 \
+            --enable-decoder=pcm_s16le \
+            --enable-demuxer=avi \
+            --enable-demuxer=wav \
+            --enable-protocol=file \
+            --enable-filter=scale \
+            --enable-static \
+            --disable-shared \
+            --extra-libs=-static \
+            --extra-cflags=--static
+          make -j$(nproc)
+          make install
+          cd ..
+          export PKG_CONFIG_PATH="/usr/local/lib/pkgconfig:$PKG_CONFIG_PATH"
+
+      - name: Configure and Build Project
+        run: |
+          mkdir build
+          meson build
+          ninja -C build

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -12,13 +12,18 @@ jobs:
         shell: msys2 {0}
 
     steps:
-
       - name: Checkout source
         uses: actions/checkout@v4
 
       - uses: actions/setup-node@v3
         with:
           node-version: 18
+
+      - name: Install ffmpeg-static via npm and add to PATH
+        shell: bash 
+        run: |
+          npm install --prefix ./tools ffmpeg-static
+          echo "$GITHUB_WORKSPACE/tools/node_modules/.bin" >> $GITHUB_PATH
 
       - name: Setup MSYS2
         uses: msys2/setup-msys2@v2
@@ -36,28 +41,6 @@ jobs:
             mingw-w64-x86_64-SDL2_ttf
             mingw-w64-x86_64-libpng
             mingw-w64-x86_64-libsndfile
-
-      - name: Build FFmpeg
-        run: |
-          git clone https://github.com/FFmpeg/FFmpeg.git
-          cd FFmpeg
-          git checkout n7.0.1
-          ./configure --disable-everything \
-            --enable-decoder=cinepak \
-            --enable-decoder=indeo3 \
-            --enable-decoder=pcm_s16le \
-            --enable-demuxer=avi \
-            --enable-demuxer=wav \
-            --enable-protocol=file \
-            --enable-filter=scale \
-            --enable-static \
-            --disable-shared \
-            --extra-libs=-static \
-            --extra-cflags=--static
-          make -j$(nproc)
-          make install
-          cd ..
-          export PKG_CONFIG_PATH="/usr/local/lib/pkgconfig:$PKG_CONFIG_PATH"
 
       - name: Configure and Build Project
         run: |

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -30,6 +30,7 @@ jobs:
             git
             nasm
             diffutils
+            vim
             mingw-w64-x86_64-gcc
             mingw-w64-x86_64-meson
             mingw-w64-x86_64-pkg-config

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -2,7 +2,7 @@ name: Windows Build
 
 on:
   push:
-    # tags: ['*']
+    tags: ['*']
 
 jobs:
   build-windows:

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -1,8 +1,6 @@
 name: Windows Build
 
-on:
-  push:
-    tags: ['*']
+on: [push, pull_request]
 
 jobs:
   build-windows:
@@ -17,10 +15,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
-
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 18
 
       - name: Setup MSYS2
         uses: msys2/setup-msys2@v2
@@ -42,9 +36,8 @@ jobs:
 
       - name: Build FFmpeg
         run: |
-          git clone https://github.com/FFmpeg/FFmpeg.git
+          git clone --depth 1 --branch n7.0.1 https://github.com/FFmpeg/FFmpeg.git
           cd FFmpeg
-          git checkout n7.0.1
           ./configure --disable-everything \
             --enable-decoder=cinepak \
             --enable-decoder=indeo3 \
@@ -57,27 +50,36 @@ jobs:
             --disable-shared \
             --disable-doc \
             --extra-libs=-static \
-            --extra-cflags=--static
+            --extra-cflags=--static \
+            --prefix=/mingw64
           make -j$(nproc)
           make install
           cd ..
-          export PKG_CONFIG_PATH="/usr/local/lib/pkgconfig:$PKG_CONFIG_PATH"
 
       - name: Configure and Build Project
         run: |
-          mkdir build
-          meson build
-          ninja -C build
+          mkdir debug
+          meson debug -Dbuildtype=debug
+          ninja -C debug
+          mkdir release
+          meson release -Dbuiltype=release
+          ninja -C release
+
+      - name: Copy licenses
+        run: |
+          ls /mingw64/share/licenses
+          mkdir dist
+          cp -r /mingw64/share/licenses dist/
+          cp fonts/*.license dist/licenses/
+
+      - name: Package
+        run: |
+          cp release/ai5.exe LICENSE README.md dist/
+          cp debug/ai5.exe dist/ai5-debug.exe
 
       - name: Upload build artifact
         uses: actions/upload-artifact@v4
         with:
           name: ai5
-          path: build/ai5.exe
-
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v1
-        with:
-          files: build/ai5.exe
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          path: dist
+          compression-level: 9

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -67,3 +67,9 @@ jobs:
           mkdir build
           meson build
           ninja -C build
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ai5-windows-build
+          path: build/ai5.exe

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -2,9 +2,6 @@ name: Windows Build (MSYS2)
 
 on:
   push:
-    branches: [main]
-  pull_request:
-    branches: [main]
 
 jobs:
   build-windows:

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -2,7 +2,7 @@ name: Windows Build
 
 on:
   push:
-    tags: ['*']
+    # tags: ['*']
 
 jobs:
   build-windows:
@@ -72,5 +72,12 @@ jobs:
       - name: Upload build artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ai5-windows-build
+          name: ai5
           path: build/ai5.exe
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: build/ai5.exe
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Checkout source
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -1,7 +1,8 @@
-name: Windows Build (MSYS2)
+name: Windows Build
 
 on:
   push:
+    tags: ['*']
 
 jobs:
   build-windows:


### PR DESCRIPTION
Hey, figured we should automate the windows builds. I tested the current CI workflow and it builds successfully with ffmpeg static mappings.

Currently it will build a windows binary on tagged releases, and the .exe will be in the releases tab. I can make CI for the other OS's too, but I figured windows .exes was most important as it's the most common OS and they don't really have nix for an easy install.

You can see a test release on my fork here: https://github.com/rpgwaiter/ai5-sdl2/releases